### PR TITLE
Improve PyMuPDF dependency instructions

### DIFF
--- a/DistractionFreeReader.pyw
+++ b/DistractionFreeReader.pyw
@@ -346,10 +346,13 @@ class PDFTimerReaderApp:
 
     def start_session(self, filepath, duration_seconds, page_num=0, is_resume=False):
         if fitz is None:
-            messagebox.showerror(
-                "Missing Dependency",
-                f"PyMuPDF is required to open PDFs.\nError: {FITZ_IMPORT_ERROR}"
+            message = (
+                "PyMuPDF could not be imported.\n"
+                "Reinstall it with 'pip install --upgrade pymupdf' and ensure the "
+                "Microsoft Visual C++ redistributable is installed.\n"
+                f"Original error: {FITZ_IMPORT_ERROR}"
             )
+            messagebox.showerror("Missing Dependency", message)
             self.reset_viewer()
             clear_state()
             return

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Additionally, the reader prevents power-button holds from forcing a shutdown whi
 ## Dependencies
 
 This reader uses [PyMuPDF](https://pymupdf.readthedocs.io/) (imported as `fitz`) to render PDF pages.
-If you encounter an error such as `ImportError: DLL load failed while importing _extra`, install the
-library for your Python environment:
+If you encounter a message like `DLL load failed while importing _extra`, the native
+components of PyMuPDF are missing. Reinstall the package and ensure the Microsoft Visual
+C++ redistributable is available:
 
 ```
-pip install pymupdf
+pip install --upgrade pymupdf
 ```
 
-Ensure the package matches your Python version and architecture.
+Both your Python interpreter and PyMuPDF must be either 32-bit or 64-bit.


### PR DESCRIPTION
## Summary
- Expand error message when PyMuPDF fails to load
- Document reinstall and Visual C++ requirements in README

## Testing
- `python -m py_compile DistractionFreeReader.pyw`
- `python DistractionFreeReader.pyw` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aed10cd08327a1f80758d3f66ed1