### PR TITLE
Restrict keyboard input to arrow keys

### DIFF
--- a/DistractionFreeReader.pyw
+++ b/DistractionFreeReader.pyw
@@ -234,6 +234,12 @@ class PDFTimerReaderApp:
         self.canvas.bind("<Button-4>", self.on_mouse_wheel)
         self.canvas.bind("<Button-5>", self.on_mouse_wheel)
 
+        # Allow navigation with arrow keys
+        self.root.bind("<Left>", lambda e: self.prev_page())
+        self.root.bind("<Right>", lambda e: self.next_page())
+        self.root.bind("<Up>", lambda e: self.canvas.yview_scroll(-1, "units"))
+        self.root.bind("<Down>", lambda e: self.canvas.yview_scroll(1, "units"))
+
     def check_for_saved_session(self):
         """Checks for and automatically restores a previously saved session."""
         saved_state = load_state()
@@ -418,6 +424,11 @@ class PDFTimerReaderApp:
         else:
             self.root.destroy()
 
+    def _block_keys(self, event):
+        """Prevents all key presses except arrow keys."""
+        if event.keysym not in {"Left", "Right", "Up", "Down"}:
+            return "break"
+
     def disable_controls(self):
         """Disables controls and shortcuts during a timed session."""
         self.root.attributes('-topmost', True)
@@ -425,8 +436,8 @@ class PDFTimerReaderApp:
         # The on_attempt_close method will handle close attempts
         self.root.protocol("WM_DELETE_WINDOW", self.on_attempt_close)
         self.root.bind("<Alt-F4>", lambda e: "break")
-        self.root.bind_all("<Control-Key>", lambda e: "break")
-        print("INFO: Distraction-free mode ENABLED. Window controls and Ctrl key are disabled.")
+        self.root.bind_all("<Key>", self._block_keys)
+        print("INFO: Distraction-free mode ENABLED. Keyboard input is restricted to arrow keys and mouse only.")
 
     def enable_controls(self):
         """Enables controls when no session is active."""
@@ -434,7 +445,7 @@ class PDFTimerReaderApp:
         self.select_button.config(state=tk.NORMAL)
         self.root.protocol("WM_DELETE_WINDOW", self.on_attempt_close)
         self.root.unbind("<Alt-F4>")
-        self.root.unbind_all("<Control-Key>")
+        self.root.unbind_all("<Key>")
         print("INFO: Distraction-free mode DISABLED. Window controls are enabled.")
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 This is a PDF Reader for distracted students and unfocused readers.
 After opening the program, choose a PDF file and enter the amount of time you want to read it for.
-Once the PDF file is selected and the timer is set, a countdown will begin. The PDF cannot be closed in any way before the countdown expires. 
+Once the PDF file is selected and the timer is set, a countdown will begin. The PDF cannot be closed in any way before the countdown expires.
 The program may restart if the PC is rebooted.
-The program can only be terminated by pressing Alt+F4 keys together, when no active timer is counting down.
+
+During an active session, all keyboard input is disabled except for the arrow keys to navigate pages or scroll. Other keys, including Alt+F4, are blocked until the timer completes.
+The program can only be terminated by pressing Alt+F4 keys together when no active timer is counting down.
 
 This will help you increase your reading time on your computer and help avoid distractions.


### PR DESCRIPTION
## Summary
- Block all keyboard input during sessions except arrow keys and mouse
- Bind arrow keys for page navigation and scrolling
- Document keyboard restrictions in README

## Testing
- `python -m py_compile DistractionFreeReader.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68a801b2ef508327ae35eaa8d0bf38b1